### PR TITLE
Fix frontmatter comment typo

### DIFF
--- a/src/transform/frontmatter.ts
+++ b/src/transform/frontmatter.ts
@@ -23,7 +23,7 @@ const escapeLiquid = (content: string): string =>
 
 /**
  * Inverse of a workaround defined above.
- * @see `escapeLiquidSubstitutionSyntax`
+ * @see `escapeLiquid`
  * @param escapedContent Input string with `{}` escaped with backslashes
  * @returns Unescaped string
  */


### PR DESCRIPTION
## Summary
- correct a reference to the `escapeLiquid` helper in `frontmatter.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68664602994083248c5de45c1c3f05b9