### PR TITLE
Fix loops executed before conditions in YFM liquid

### DIFF
--- a/src/transform/liquid/index.ts
+++ b/src/transform/liquid/index.ts
@@ -117,13 +117,13 @@ function liquidSnippet<
         }, {});
     }
 
-    if (cycles) {
-        output = applyCycles(output, vars, path, {sourceMap});
-    }
-
     if (conditions) {
         const strict = conditions === 'strict';
         output = applyConditions(output, vars, path, {sourceMap, strict, useLegacyConditions});
+    }
+
+    if (cycles) {
+        output = applyCycles(output, vars, path, {sourceMap});
     }
 
     if (substitutions) {

--- a/test/liquid/for-if-order.test.ts
+++ b/test/liquid/for-if-order.test.ts
@@ -1,0 +1,23 @@
+import dedent from 'ts-dedent';
+
+import {liquidSnippet} from '../../src/transform/liquid';
+import {log} from '../../src/transform/log';
+
+describe('Cycles with conditions', () => {
+    beforeEach(() => {
+        log.clear();
+    });
+
+    test('for loop inside if should not run when condition is false', () => {
+        const input = dedent`
+            {% if test.testarray %}
+            {% for testval in test.testarray %}
+            - {{ testval }}
+            {% endfor %}
+            {% endif %}
+        `;
+        const result = liquidSnippet(input, {test: {t: 1}}, 'test.md');
+        expect(result.trim()).toEqual('');
+        expect(log.get().error.length).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- process Liquid `if` conditions before `for` loops
- add regression test for the issue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68680bce5e3c8324851c89777a363f8b