### PR TITLE
fix: guard markdown-it-meta against malformed frontmatter

### DIFF
--- a/src/transform/plugins/meta.ts
+++ b/src/transform/plugins/meta.ts
@@ -1,6 +1,55 @@
+import type StateBlock from 'markdown-it/lib/rules_block/state_block';
 import type {MarkdownItPluginCb} from './typings';
 
 // @ts-expect-error
 import meta from 'markdown-it-meta';
 
-export = meta as MarkdownItPluginCb;
+const plugin: MarkdownItPluginCb = (md) => {
+    meta(md);
+
+    const rules = (
+        md.block.ruler as unknown as {
+            __rules__: {name: string; fn: Function}[];
+        }
+    ).__rules__;
+    const rule = rules.find((r) => r.name === 'meta');
+    if (!rule) {
+        return;
+    }
+
+    const original = rule.fn as unknown as (
+        state: StateBlock,
+        startLine: number,
+        endLine: number,
+        silent: boolean,
+    ) => boolean;
+
+    const getLine = (state: StateBlock, line: number) => {
+        const pos = state.bMarks[line];
+        const max = state.eMarks[line];
+        return state.src.slice(pos, max);
+    };
+
+    rule.fn = (state: StateBlock, start: number, end: number, silent: boolean) => {
+        if (start === 0 && state.tShift[start] >= 0 && getLine(state, start).trim() === '---') {
+            let line = start + 1;
+            while (line < end && getLine(state, line).trim() !== '---') {
+                if (state.tShift[line] < 0) {
+                    break;
+                }
+                line++;
+            }
+            if (line >= end) {
+                return false;
+            }
+        }
+
+        try {
+            return original(state, start, end, silent);
+        } catch {
+            return false;
+        }
+    };
+};
+
+export = plugin;

--- a/test/__snapshots__/frontmatter-start.test.ts.snap
+++ b/test/__snapshots__/frontmatter-start.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`documents starting with --- renders leading --- as horizontal rule 1`] = `
+<hr>
+<p>
+  {{bad}}
+  <br>
+  Content
+</p>
+`;

--- a/test/frontmatter-start.test.ts
+++ b/test/frontmatter-start.test.ts
@@ -1,0 +1,27 @@
+import dedent from 'ts-dedent';
+import MarkdownIt from 'markdown-it';
+// @ts-expect-error
+import meta from 'markdown-it-meta';
+
+import transform from '../src/transform';
+
+describe('documents starting with ---', () => {
+    const input = dedent`
+    ---
+    {{bad}}
+    Content
+    `;
+
+    it('markdown-it-meta throws on malformed frontmatter', () => {
+        const md = new MarkdownIt();
+        md.use(meta);
+        expect(() => md.render(input)).toThrow();
+    });
+
+    it('renders leading --- as horizontal rule', () => {
+        const {
+            result: {html},
+        } = transform(input);
+        expect(html).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
## Summary
- wrap `markdown-it-meta` to skip unclosed frontmatter and swallow YAML errors
- document the bug with a regression test

## Testing
- `npm test --silent -- --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_6899e9a8b7f8832495d74929cccf06cb